### PR TITLE
Fix IFD dragon steels mining speed and correctly update damage

### DIFF
--- a/src/main/java/tcintegrations/data/tcon/material/MaterialStatsDataProvider.java
+++ b/src/main/java/tcintegrations/data/tcon/material/MaterialStatsDataProvider.java
@@ -114,21 +114,21 @@ public class MaterialStatsDataProvider extends AbstractMaterialStatsDataProvider
             new GripMaterialStats(0.2F, -0.15F, 3.0F),
             HandleMaterialStats.multipliers().durability(1.4F).miningSpeed(1.2F).attackSpeed(1.1F).attackDamage(1.25F).build(),
             StatlessMaterialStats.BINDING);
-        addMaterialStats(MaterialIds.dragonsteelFire, new HeadMaterialStats(2500, 20F, NETHERITE, 2.5F));
+        addMaterialStats(MaterialIds.dragonsteelFire, new HeadMaterialStats(2500, 6.5F, NETHERITE, 20F));
         addArmorShieldStats(MaterialIds.dragonsteelFire,
             PlatingMaterialStats.builder()
                 .durabilityFactor(60)
                 .armor(6, 9, 12, 7)
                 .toughness(4),
             StatlessMaterialStats.MAILLE);
-        addMaterialStats(MaterialIds.dragonsteelIce, new HeadMaterialStats(2500, 20F, NETHERITE, 2.5F));
+        addMaterialStats(MaterialIds.dragonsteelIce, new HeadMaterialStats(2500, 6.5F, NETHERITE, 20F));
         addArmorShieldStats(MaterialIds.dragonsteelIce,
             PlatingMaterialStats.builder()
                 .durabilityFactor(60)
                 .armor(6, 9, 12, 7)
                 .toughness(4),
             StatlessMaterialStats.MAILLE);
-        addMaterialStats(MaterialIds.dragonsteelLightning, new HeadMaterialStats(2500, 20F, NETHERITE, 2.5F));
+        addMaterialStats(MaterialIds.dragonsteelLightning, new HeadMaterialStats(2500, 6.5F, NETHERITE, 20F));
         addArmorShieldStats(MaterialIds.dragonsteelLightning,
             PlatingMaterialStats.builder()
                 .durabilityFactor(60)


### PR DESCRIPTION
Reverted the mining speed back to 6.5 from 20, and correctly updated damage to 20.